### PR TITLE
Fix error - RuntimeException: Failed to start the session

### DIFF
--- a/src/Plugin/ContextReaction/DenyAccessReaction.php
+++ b/src/Plugin/ContextReaction/DenyAccessReaction.php
@@ -47,7 +47,7 @@ class DenyAccessReaction extends ContextReactionPluginBase {
       $redirect_url = $config['proxy_prepend_url'] . $current_url;
       $response = new RedirectResponse($redirect_url);
       $response->send();
-      return $response;
+      exit;
     }
   }
 


### PR DESCRIPTION
Fixing this error:

`RuntimeException: Failed to start the session because headers have already been sent by "/var/www/html/drupal/vendor/symfony/http-foundation/Response.php" at line 1239. in Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage->start() (line 152 of /var/www/html/drupal/vendor/symfony/http-foundation/Session/Storage/NativeSessionStorage.php)`

when using the EZproxy within Drupal 9.4.x